### PR TITLE
Improve product upload form

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ npm run dev
 - Middleware que protege las rutas de administración.
 
 El diseño utiliza un tema oscuro con detalles en dorado y la fuente Geist.
+
+## Esquema de productos
+
+El proyecto utiliza una tabla `products` en Supabase. El script SQL para crearla se encuentra en `supabase/schema.sql`.
+
+| Columna     | Tipo        | Requerido | Default             | Comentario                     |
+|-------------|-------------|-----------|---------------------|-------------------------------|
+| id          | uuid        | ✅        | uuid_generate_v4()  | Identificador único           |
+| name        | text        | ✅        | —                   | Nombre del producto           |
+| description | text        | ❌        | —                   | Descripción corta             |
+| brand       | text        | ❌        | —                   | Marca o productor             |
+| category    | text        | ❌        | —                   | Categoría del producto        |
+| price       | integer     | ✅        | —                   | Precio en pesos               |
+| stock       | integer     | ✅        | 0                   | Cantidad disponible           |
+| available   | boolean     | ✅        | true                | Visible al público            |
+| image_url   | text        | ❌        | —                   | URL pública de la imagen      |
+| created_at  | timestamptz | ✅        | now()               | Fecha de creación             |
+| updated_at  | timestamptz | ✅        | now()               | Fecha de última actualización |
+
+La tabla cuenta con índices en las columnas `available`, `category` y `brand` para
+mejorar las consultas. Además, incluye un trigger que actualiza el campo
+`updated_at` cada vez que se modifica un registro.
+

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -13,6 +13,8 @@ export default function EditProductPage() {
   interface FormState {
     name: string
     description: string
+    brand: string
+    category: string
     price: string
     stock: string
     available: boolean
@@ -21,6 +23,8 @@ export default function EditProductPage() {
   const [form, setForm] = useState<FormState>({
     name: '',
     description: '',
+    brand: '',
+    category: '',
     price: '',
     stock: '',
     available: true,
@@ -34,6 +38,8 @@ export default function EditProductPage() {
         setForm({
           name: data.name,
           description: data.description,
+          brand: data.brand ?? '',
+          category: data.category ?? '',
           price: String(data.price),
           stock: String(data.stock),
           available: data.available,
@@ -71,9 +77,12 @@ export default function EditProductPage() {
       .update({
         name: form.name,
         description: form.description,
+        brand: form.brand,
+        category: form.category,
         price: Number(form.price),
         stock: Number(form.stock),
         available: form.available,
+        updated_at: new Date().toISOString(),
         ...(imageUrl ? { image_url: imageUrl } : {}),
       })
       .eq('id', productId)
@@ -110,6 +119,22 @@ export default function EditProductPage() {
           name="description"
           placeholder="Descripción"
           value={form.description}
+          onChange={handleChange}
+          className="p-2 rounded bg-black text-white border border-gray-600"
+        />
+        <input
+          type="text"
+          name="brand"
+          placeholder="Marca"
+          value={form.brand}
+          onChange={handleChange}
+          className="p-2 rounded bg-black text-white border border-gray-600"
+        />
+        <input
+          type="text"
+          name="category"
+          placeholder="Categoría"
+          value={form.category}
           onChange={handleChange}
           className="p-2 rounded bg-black text-white border border-gray-600"
         />

--- a/src/app/admin/new/page.tsx
+++ b/src/app/admin/new/page.tsx
@@ -10,6 +10,8 @@ export default function CreateProductPage() {
     const [form, setForm] = useState({
         name: '',
         description: '',
+        brand: '',
+        category: '',
         price: '',
         stock: '',
         available: true,
@@ -45,6 +47,8 @@ export default function CreateProductPage() {
         const { error } = await supabase.from('products').insert({
             name: form.name,
             description: form.description,
+            brand: form.brand,
+            category: form.category,
             price: Number(form.price),
             stock: Number(form.stock),
             image_url: imageUrl,
@@ -78,6 +82,22 @@ export default function CreateProductPage() {
                     name="description"
                     placeholder="Descripción"
                     value={form.description}
+                    onChange={handleChange}
+                    className="p-2 rounded bg-black text-white border border-gray-600"
+                />
+                <input
+                    type="text"
+                    name="brand"
+                    placeholder="Marca"
+                    value={form.brand}
+                    onChange={handleChange}
+                    className="p-2 rounded bg-black text-white border border-gray-600"
+                />
+                <input
+                    type="text"
+                    name="category"
+                    placeholder="Categoría"
+                    value={form.category}
                     onChange={handleChange}
                     className="p-2 rounded bg-black text-white border border-gray-600"
                 />

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,32 @@
+-- SQL schema for the products table
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS products (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name text NOT NULL,
+    description text,
+    brand text,
+    category text,
+    price integer NOT NULL CHECK (price >= 0),
+    stock integer NOT NULL DEFAULT 0,
+    available boolean NOT NULL DEFAULT true,
+    image_url text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_products_updated_at
+BEFORE UPDATE ON products
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS idx_products_available ON products(available);
+CREATE INDEX IF NOT EXISTS idx_products_category ON products(category);
+CREATE INDEX IF NOT EXISTS idx_products_brand ON products(brand);


### PR DESCRIPTION
## Summary
- add brand and category inputs on product forms
- update edit/create pages to store the new fields
- document indices and trigger for updated_at
- update schema with indices and trigger

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686142251e14832385096a78a9ceb25d