### PR TITLE
Add image URL input to product forms

### DIFF
--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -16,6 +16,7 @@ export default function EditProductPage() {
     price: string
     stock: string
     available: boolean
+    image_url: string
   }
 
   const [form, setForm] = useState<FormState>({
@@ -24,6 +25,7 @@ export default function EditProductPage() {
     price: '',
     stock: '',
     available: true,
+    image_url: '',
   })
   const [imageFile, setImageFile] = useState<File | null>(null)
 
@@ -37,6 +39,7 @@ export default function EditProductPage() {
           price: String(data.price),
           stock: String(data.stock),
           available: data.available,
+          image_url: data.image_url,
         })
       }
       setLoading(false)
@@ -56,7 +59,7 @@ export default function EditProductPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-  let imageUrl = ''
+  let imageUrl = form.image_url
   if (imageFile) {
     const uploaded = await uploadProductImage(imageFile)
     if (!uploaded) {
@@ -74,7 +77,7 @@ export default function EditProductPage() {
         price: Number(form.price),
         stock: Number(form.stock),
         available: form.available,
-        ...(imageUrl ? { image_url: imageUrl } : {}),
+        image_url: imageUrl,
       })
       .eq('id', productId)
 
@@ -132,6 +135,14 @@ export default function EditProductPage() {
           className="p-2 rounded bg-black text-white border border-gray-600"
         />
         <input type="file" accept="image/*" onChange={(e) => setImageFile(e.target.files?.[0] ?? null)} className="text-sm text-gray-300" />
+        <input
+          type="text"
+          name="image_url"
+          placeholder="URL de la imagen"
+          value={form.image_url}
+          onChange={handleChange}
+          className="p-2 rounded bg-black text-white border border-gray-600"
+        />
         <label className="flex items-center gap-2">
           <input type="checkbox" name="available" checked={form.available} onChange={handleChange} />
           Disponible

--- a/src/app/admin/new/page.tsx
+++ b/src/app/admin/new/page.tsx
@@ -13,6 +13,7 @@ export default function CreateProductPage() {
         price: '',
         stock: '',
         available: true,
+        image_url: '',
     });
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [uploading, setUploading] = useState(false);
@@ -30,7 +31,7 @@ export default function CreateProductPage() {
         e.preventDefault();
         setUploading(true);
 
-        let imageUrl = '';
+        let imageUrl = form.image_url;
 
         if (imageFile) {
             const uploaded = await uploadProductImage(imageFile);
@@ -104,6 +105,14 @@ export default function CreateProductPage() {
                     accept="image/*"
                     onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
                     className="text-sm text-gray-300"
+                />
+                <input
+                    type="text"
+                    name="image_url"
+                    placeholder="URL de la imagen"
+                    value={form.image_url}
+                    onChange={handleChange}
+                    className="p-2 rounded bg-black text-white border border-gray-600"
                 />
                 <label className="flex items-center gap-2">
                     <input

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -21,6 +21,7 @@ export default async function AdminPage() {
                             <th className="p-2 text-left border-b border-gold">Nombre</th>
                             <th className="p-2 text-left border-b border-gold">Precio</th>
                             <th className="p-2 text-left border-b border-gold">Stock</th>
+                            <th className="p-2 text-left border-b border-gold">Disponible</th>
                             <th className="p-2 text-left border-b border-gold">Acciones</th>
                         </tr>
                     </thead>
@@ -30,6 +31,7 @@ export default async function AdminPage() {
                                 <td className="p-2">{product.name}</td>
                                 <td className="p-2">${product.price.toLocaleString()}</td>
                                 <td className="p-2">{product.stock}</td>
+                                <td className="p-2">{product.available ? 'Sí' : 'No'}</td>
                                 <td className="p-2">
                                     <Link
                                         href={`/admin/edit/${product.id}`}


### PR DESCRIPTION
## Summary
- allow specifying image URLs when creating or editing products
- display product availability in admin panel

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686144062d608323bcd185fc34d48ca6