### PR TITLE
Fix admin redirect loop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,11 @@ import type { NextRequest } from 'next/server'
 export function middleware(req: NextRequest) {
   const token = req.cookies.get('sb-access-token')?.value
 
-  if (!token && req.nextUrl.pathname.startsWith('/admin')) {
+  if (
+    !token &&
+    req.nextUrl.pathname.startsWith('/admin') &&
+    req.nextUrl.pathname !== '/admin/login'
+  ) {
     const redirectUrl = new URL('/admin/login', req.url)
     redirectUrl.searchParams.set('redirect', req.nextUrl.pathname)
     return NextResponse.redirect(redirectUrl)


### PR DESCRIPTION
## Summary
- avoid redirect loop when navigating to `/admin/login`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_686144bf3ec8832397f03c2672ac018a