### PR TITLE
Improve upload error handling

### DIFF
--- a/src/lib/uploadImage.ts
+++ b/src/lib/uploadImage.ts
@@ -1,12 +1,17 @@
 import { supabase } from './supabase'
 
 export const uploadProductImage = async (file: File): Promise<string | null> => {
-  const fileName = `product-${Date.now()}`
-  const { error } = await supabase.storage.from('licorera').upload(fileName, file)
+  const extension = file.name.split('.').pop() ?? ''
+  const fileName = `product-${Date.now()}${extension ? `.${extension}` : ''}`
+  const { error } = await supabase.storage
+    .from('licorera')
+    .upload(fileName, file, { upsert: true })
+
   if (error) {
-    console.error('Error al subir imagen:', error)
+    console.error('Error al subir imagen:', error.message)
     return null
   }
+
   const { data: publicUrlData } = supabase.storage.from('licorera').getPublicUrl(fileName)
   return publicUrlData?.publicUrl ?? null
 }


### PR DESCRIPTION
## Summary
- handle file extension when uploading images
- allow overwriting images with `upsert: true`
- log the specific error message

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68614779fbac8323b774f7f228aca194