### PR TITLE
Protect admin pages with auth check

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 export function middleware(req: NextRequest) {
-  const token = req.cookies.get('sb-access-token')?.value
-
+  const loggedIn = req.cookies.get('logged-in')?.value
 
   if (
-    !token &&
+    !loggedIn &&
     req.nextUrl.pathname.startsWith('/admin') &&
     req.nextUrl.pathname !== '/admin/login'
   ) {
-
     const redirectUrl = new URL('/admin/login', req.url)
     redirectUrl.searchParams.set('redirect', req.nextUrl.pathname)
     return NextResponse.redirect(redirectUrl)

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const protect = async () => {
+      if (pathname === '/admin/login') {
+        setLoading(false)
+        return
+      }
+
+      const { data } = await supabase.auth.getSession()
+      if (!data.session) {
+        router.replace(`/admin/login?redirect=${encodeURIComponent(pathname)}`)
+      } else {
+        setLoading(false)
+      }
+    }
+    protect()
+  }, [pathname, router])
+
+  if (loading) {
+    return <p className="text-white p-4">Cargando...</p>
+  }
+
+  return <>{children}</>
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -27,6 +27,7 @@ export default function LoginPage() {
         if (error) {
             setErrorMsg('Correo o contraseña incorrectos');
         } else {
+            document.cookie = 'logged-in=true; path=/';
             const redirect = searchParams.get('redirect') || '/admin';
             router.push(redirect);
         }


### PR DESCRIPTION
## Summary
- add a layout under `/admin` to verify session using Supabase
- store a simple cookie when logging in
- check the cookie from `middleware.ts` to redirect unauthenticated users

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68614ce3f02c83239e0ae28439b23a2a