### PR TITLE
Add simple product form

### DIFF
--- a/src/app/admin/new/page.tsx
+++ b/src/app/admin/new/page.tsx
@@ -10,15 +10,13 @@ export default function CreateProductPage() {
     const [form, setForm] = useState({
         name: '',
         description: '',
-        brand: '',
-        category: '',
         price: '',
         stock: '',
         available: true,
-        image_url: '',
     });
     const [imageFile, setImageFile] = useState<File | null>(null);
-    const [uploading, setUploading] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [errorMsg, setErrorMsg] = useState('');
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const target = e.target as HTMLInputElement;
@@ -31,15 +29,16 @@ export default function CreateProductPage() {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        setUploading(true);
+        setLoading(true);
+        setErrorMsg('');
 
-        let imageUrl = form.image_url;
+        let imageUrl = '';
 
         if (imageFile) {
             const uploaded = await uploadProductImage(imageFile);
             if (!uploaded) {
-                alert('Error subiendo imagen');
-                setUploading(false);
+                setErrorMsg('Error subiendo imagen');
+                setLoading(false);
                 return;
             }
             imageUrl = uploaded;
@@ -48,18 +47,16 @@ export default function CreateProductPage() {
         const { error } = await supabase.from('products').insert({
             name: form.name,
             description: form.description,
-            brand: form.brand,
-            category: form.category,
             price: Number(form.price),
             stock: Number(form.stock),
             image_url: imageUrl,
             available: form.available,
         });
 
-        setUploading(false);
+        setLoading(false);
 
         if (error) {
-            alert('Error al crear producto');
+            setErrorMsg('Error al crear producto');
             console.error(error);
         } else {
             router.push('/admin');
@@ -69,6 +66,11 @@ export default function CreateProductPage() {
     return (
         <main className="max-w-xl mx-auto mt-10 text-white bg-gradient-to-b from-[#1c1c1c] to-black p-4 sm:p-6 rounded-lg shadow-lg">
             <h1 className="text-xl sm:text-2xl font-bold mb-6">Agregar Producto</h1>
+            {errorMsg && (
+                <div className="bg-red-500 text-white p-2 rounded mb-4 text-sm">
+                    {errorMsg}
+                </div>
+            )}
             <form onSubmit={handleSubmit} className="flex flex-col gap-4 bg-[#2e2e2e] p-4 sm:p-6 rounded-lg border border-gold shadow-lg">
                 <input
                     type="text"
@@ -83,22 +85,6 @@ export default function CreateProductPage() {
                     name="description"
                     placeholder="Descripción"
                     value={form.description}
-                    onChange={handleChange}
-                    className="p-2 rounded bg-black text-white border border-gray-600"
-                />
-                <input
-                    type="text"
-                    name="brand"
-                    placeholder="Marca"
-                    value={form.brand}
-                    onChange={handleChange}
-                    className="p-2 rounded bg-black text-white border border-gray-600"
-                />
-                <input
-                    type="text"
-                    name="category"
-                    placeholder="Categoría"
-                    value={form.category}
                     onChange={handleChange}
                     className="p-2 rounded bg-black text-white border border-gray-600"
                 />
@@ -126,14 +112,6 @@ export default function CreateProductPage() {
                     onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
                     className="text-sm text-gray-300"
                 />
-                <input
-                    type="text"
-                    name="image_url"
-                    placeholder="URL de la imagen"
-                    value={form.image_url}
-                    onChange={handleChange}
-                    className="p-2 rounded bg-black text-white border border-gray-600"
-                />
                 <label className="flex items-center gap-2">
                     <input
                         type="checkbox"
@@ -145,10 +123,10 @@ export default function CreateProductPage() {
                 </label>
                 <button
                     type="submit"
-                    disabled={uploading}
+                    disabled={loading}
                     className="bg-gold text-black text-lg font-semibold py-2 rounded-md w-full border border-black/20 shadow-lg hover:bg-yellow-400 transition"
                 >
-                    {uploading ? 'Guardando...' : 'Guardar producto'}
+                    {loading ? 'Guardando...' : 'Guardar producto'}
                 </button>
             </form>
         </main>


### PR DESCRIPTION
## Summary
- simplify product creation form to match schema without brand/category fields
- show errors if upload or insert fail
- redirect to `/admin` after creation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861531acd7c83238b6acc1762ed63ea